### PR TITLE
Fix/Remove popup responses from sendedAnswer

### DIFF
--- a/packages/platform-tg/package.json
+++ b/packages/platform-tg/package.json
@@ -14,7 +14,7 @@
     "lib/"
   ],
   "license": "MIT",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "main": "lib/index.js",
   "dependencies": {

--- a/packages/platform-tg/src/context.ts
+++ b/packages/platform-tg/src/context.ts
@@ -86,7 +86,8 @@ export default class PlatformTgContext extends PlatformContext {
 
   public async send(message: ISendMessageOptions, isAnswer = false) {
     if (this.raw.update.callback_query && message.payload?.popup) {
-      return this.raw.answerCbQuery(message.text);
+      await this.raw.answerCbQuery(message.text);
+      return this.sendedAnswer;
     }
 
     let files: Upload[];


### PR DESCRIPTION
Now `Context#answer` will not cause an error when a `popup` response is already sent.