### PR TITLE
Fix/Command finding error

### DIFF
--- a/packages/botcmd/package.json
+++ b/packages/botcmd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@henta/botcmd",
   "description": "Command parser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/botcmd/src/container.ts
+++ b/packages/botcmd/src/container.ts
@@ -24,12 +24,36 @@ export default class BotcmdContainer {
     commandLine: string,
   ): { pattern: string; command: IBuildedCommand } | null {
     // maybe faster?
-    for (const [key, value] of this.commandByName) {
-      if (key === commandLine || `${commandLine} `.startsWith(key)) {
-        return { pattern: key, command: value };
+    const preparedCommand = commandLine.split(' ');
+
+    let maxMatches = -1;
+    let closestArray: string[] = null;
+    let closestCommand: ReturnType<BotcmdContainer['find']> = null;
+
+    for (const [key, command] of this.commandByName) {
+      const preparedKey = key.split(' ');
+      // Without set, sub-commands containing a similar string to parent command will always override.
+      // This solution causes a bug, but it's a better way.
+      const inclusion = new Set(
+        preparedKey.filter((item) => preparedCommand.includes(item)),
+      );
+
+      const matches = inclusion.size;
+      if (!matches) {
+        continue;
+      }
+
+      if (
+        matches > maxMatches ||
+        // Prefer more basic commands.
+        (matches === maxMatches && closestArray?.length > preparedKey.length)
+      ) {
+        maxMatches = matches;
+        closestArray = preparedKey;
+        closestCommand = { pattern: key, command };
       }
     }
 
-    return null;
+    return closestCommand;
   }
 }


### PR DESCRIPTION
Old version of method had a bug: `'${commandLine} '.startsWith(key)` didn't work properly.
E.g. `h` as an alias of `home` command will be executed by `https://..`" because `'https://...'.startsWith('h')` is `true`.

My method also contains a bug: between `/service` and `/service service` commands in `/service service 1` `/service` command will be selected.

Without using `Set` it will be other way around: between `/service` and `/service service` commands in `/service service 1` `/service service` command will be selected, but there are far fewer such cases, so I'll keep current version.